### PR TITLE
Move to RSpec 3 and expect syntax

### DIFF
--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   end
   s.add_dependency 'i18n', '>= 0.4.1' # fix for mail/activesupport-3 dependency issue
 
-  s.add_development_dependency 'rspec', '~> 2.10'
+  s.add_development_dependency 'rspec', '~> 3.0'
 
   s.files        = Dir.glob('{bin,lib,examples}/**/*') + %w(LICENSE README.md USER_GUIDE.md CHANGELOG.md)
   s.require_path = 'lib'

--- a/spec/mailman/application_spec.rb
+++ b/spec/mailman/application_spec.rb
@@ -9,17 +9,17 @@ describe Mailman::Application do
     end
 
     it 'should initialize and store the router' do
-      @app.router.class.should == Mailman::Router
+      expect(@app.router.class).to eq(Mailman::Router)
     end
 
     it 'should initialize and store the message processor' do
-      @app.processor.class.should == Mailman::MessageProcessor
+      expect(@app.processor.class).to eq(Mailman::MessageProcessor)
     end
 
     context "with global config" do
       it 'should use the global config' do
-        @app.config.class.should == Mailman::Configuration
-        @app.config.should == Mailman.config
+        expect(@app.config.class).to eq(Mailman::Configuration)
+        expect(@app.config).to eq(Mailman.config)
       end
     end
 
@@ -30,15 +30,15 @@ describe Mailman::Application do
         end
 
         it "should instanciate the configuration" do
-          @app.config.should be_a(Mailman::Configuration)
+          expect(@app.config).to be_a(Mailman::Configuration)
         end
 
         it "should instanciate a config instance with params" do
-          @app.config.poll_interval.should == 10
+          expect(@app.config.poll_interval).to eq(10)
         end
 
         it 'should not use the global config' do
-          @app.config.should_not == Mailman.config
+          expect(@app.config).to_not eq(Mailman.config)
         end
       end
 
@@ -50,15 +50,15 @@ describe Mailman::Application do
         end
 
         it "should instanciate the configuration" do
-          @app.config.should be_a(Mailman::Configuration)
+          expect(@app.config).to be_a(Mailman::Configuration)
         end
 
         it "should instanciate a config instance with params" do
-          @app.config.poll_interval.should == 10
+          expect(@app.config.poll_interval).to eq(10)
         end
 
         it 'should not use the global config' do
-          @app.config.should_not == Mailman.config
+          expect(@app.config).to_not eq(Mailman.config)
         end
       end
     end
@@ -74,15 +74,15 @@ describe Mailman::Application do
 
       it "should catch interrupt signal and let a POP3 receiver finish its poll before exiting" do
         @mock_receiver = double("Receiver::POP3")
-        @mock_receiver.stub(:connect)
-        @mock_receiver.stub(:get_messages) {Process.kill("INT", $$)}
-        @mock_receiver.should_receive(:disconnect).at_most(:twice)
-        @mock_receiver.should_receive(:started?).at_most(:twice)
-        Mailman::Receiver::POP3.stub(:new) {@mock_receiver}
+        allow(@mock_receiver).to receive(:connect)
+        allow(@mock_receiver).to receive(:get_messages) { Process.kill("INT", $$) }
+        expect(@mock_receiver).to receive(:disconnect).at_most(:twice)
+        expect(@mock_receiver).to receive(:started?).at_most(:twice)
+        allow(Mailman::Receiver::POP3).to receive(:new).and_return(@mock_receiver)
 
         Mailman.config.pop3 = {}
 
-        Signal.trap("INT") {raise "Application didn't catch SIGINT"}
+        Signal.trap("INT") { raise "Application didn't catch SIGINT" }
         @app.run
       end
     end

--- a/spec/mailman/configuration_spec.rb
+++ b/spec/mailman/configuration_spec.rb
@@ -10,63 +10,63 @@ describe Mailman::Configuration do
 
   it 'should have a default logger' do
     config.logger = nil
-    config.logger.instance_variable_get('@logdev').dev.should == STDOUT
+    expect(config.logger.instance_variable_get('@logdev').dev).to eq(STDOUT)
   end
 
   it 'should store a custom logger' do
     config.logger = Logger.new(STDERR)
-    config.logger.instance_variable_get('@logdev').dev.should == STDERR
+    expect(config.logger.instance_variable_get('@logdev').dev).to eq(STDERR)
   end
 
   it 'should store the POP3 config hash' do
     config.pop3 = {:user => 'foo'}
-    config.pop3.should == {:user => 'foo'}
+    expect(config.pop3).to eq({:user => 'foo'})
   end
 
   it 'should have a default poll interval' do
     config.poll_interval = nil
-    config.poll_interval.should == 60
+    expect(config.poll_interval).to eq(60)
   end
 
   it 'should store the poll interval' do
     config.poll_interval = 20
-    config.poll_interval.should == 20
+    expect(config.poll_interval).to eq(20)
   end
 
   it 'should store the maildir location' do
     config.maildir = '../maildir-test'
-    config.maildir.should == '../maildir-test'
+    expect(config.maildir).to eq('../maildir-test')
   end
 
   it 'should have a defaut watch maildir setting' do
-    config.watch_maildir.should == true
+    expect(config.watch_maildir).to eq(true)
   end
 
   it 'should store the maildir listen setting' do
     config.watch_maildir = false
-    config.watch_maildir.should == false
+    expect(config.watch_maildir).to eq(false)
   end
 
   it 'should have a default rails root' do
-    config.rails_root.should == '.'
+    expect(config.rails_root).to eq('.')
   end
 
   it 'should store a custom rails root' do
     config.rails_root = 'test-app'
-    config.rails_root.should == 'test-app'
+    expect(config.rails_root).to eq('test-app')
   end
   
   it 'should default to not ignoring stdin' do
-    config.ignore_stdin.should == nil
+    expect(config.ignore_stdin).to eq(nil)
   end
   
   it 'should store ignore_stdin setting' do
     config.ignore_stdin = true
-    config.ignore_stdin.should == true
+    expect(config.ignore_stdin).to eq(true)
   end
 
   it "should store graceful_death flag" do
     config.graceful_death = true
-    config.graceful_death.should == true
+    expect(config.graceful_death).to eq(true)
   end
 end

--- a/spec/mailman/message_processor_spec.rb
+++ b/spec/mailman/message_processor_spec.rb
@@ -11,17 +11,17 @@ describe Mailman::MessageProcessor do
 
   describe "#process" do
     it 'should process a message and pass it to the router' do
-      router.should_receive(:route).with(basic_email).and_return(true)
-      processor.process(basic_email).should be_truthy
+      expect(router).to receive(:route).with(basic_email).and_return(true)
+      expect(processor.process(basic_email)).to be_truthy
     end
 
     it 'should log in info the new message received' do
-      Mailman.logger.should_receive(:info).with("Got new message from '#{basic_email.from.first}' with subject '#{basic_email.subject}'.")
+      expect(Mailman.logger).to receive(:info).with("Got new message from '#{basic_email.from.first}' with subject '#{basic_email.subject}'.")
       processor.process(basic_email)
     end
 
     it 'should receive email without from field' do
-      Mailman.logger.should_receive(:info).with("Got new message from 'unknown' with subject '#{basic_email.subject}'.")
+      expect(Mailman.logger).to receive(:info).with("Got new message from 'unknown' with subject '#{basic_email.subject}'.")
       processor.process(no_from_mail)
     end
 
@@ -31,28 +31,28 @@ describe Mailman::MessageProcessor do
     before { setup_maildir }
     it 'should mark message like seen' do
       processor.process_maildir_message(maildir_message)
-      maildir_message.should be_seen
+      expect(maildir_message).to be_seen
     end
 
     it 'should move to current' do
       processor.process_maildir_message(maildir_message)
-      maildir_message.dir.should == :cur
+      expect(maildir_message.dir).to eq(:cur)
     end
 
     it 'should not move file in cur if process failed' do
-      router.should_receive(:route).with(basic_email).and_raise(Exception)
+      expect(router).to receive(:route).with(basic_email).and_raise(Exception)
       begin
         processor.process_maildir_message(maildir_message)
       rescue Exception
       end
-      maildir_message.dir.should_not == :cur
+      expect(maildir_message.dir).to_not eq(:cur)
     end
 
     it 'should log errors caused by processing the message, but not raise them so futher messages can be processed' do
       error = StandardError.new('testing')
-      router.should_receive(:route).with(basic_email).and_raise(error)
-      Mailman.logger.should_receive(:error)
-      lambda{ processor.process_maildir_message(maildir_message) }.should_not raise_error
+      expect(router).to receive(:route).with(basic_email).and_raise(error)
+      expect(Mailman.logger).to receive(:error)
+      expect(lambda{ processor.process_maildir_message(maildir_message) }).to_not raise_error
     end
   end
 

--- a/spec/mailman/middleware_spec.rb
+++ b/spec/mailman/middleware_spec.rb
@@ -18,7 +18,7 @@ describe Mailman::Middleware do
   describe "#add" do
     it "should add middleware to the end of the stack" do
       middleware.add ExampleMiddleware
-      middleware.instance_variable_get('@entries').last.should == ExampleMiddleware
+      expect(middleware.instance_variable_get('@entries').last).to eq(ExampleMiddleware)
     end
   end
 
@@ -26,7 +26,7 @@ describe Mailman::Middleware do
     it "should remove the middleware from the stack" do
       middleware.add AnotherMiddleware
       middleware.remove AnotherMiddleware
-      middleware.instance_variable_get('@entries').should be_empty
+      expect(middleware.instance_variable_get('@entries')).to be_empty
     end
   end
 
@@ -34,7 +34,7 @@ describe Mailman::Middleware do
     it "should add middleware to the correct location in the stack" do
       middleware.add AnotherMiddleware
       middleware.insert_before AnotherMiddleware, ExampleMiddleware
-      middleware.instance_variable_get('@entries').first.should == ExampleMiddleware
+      expect(middleware.instance_variable_get('@entries').first).to eq(ExampleMiddleware)
     end
   end
 
@@ -42,7 +42,7 @@ describe Mailman::Middleware do
     it "should add middleware to the correct location in the stack" do
       middleware.add AnotherMiddleware
       middleware.insert_after AnotherMiddleware, ExampleMiddleware
-      middleware.instance_variable_get('@entries').last.should == ExampleMiddleware
+      expect(middleware.instance_variable_get('@entries').last).to eq(ExampleMiddleware)
     end
   end
 
@@ -50,7 +50,7 @@ describe Mailman::Middleware do
     it "should run all middleware in the stack" do
       [ExampleMiddleware, AnotherMiddleware].each do |middleware_class|
         middleware.add middleware_class
-        middleware_class.any_instance.should_receive(:call).and_call_original
+        allow_any_instance_of(middleware_class).to receive(:call).and_call_original
       end
 
       middleware.run({}) {}

--- a/spec/mailman/receiver/imap_spec.rb
+++ b/spec/mailman/receiver/imap_spec.rb
@@ -16,29 +16,29 @@ describe Mailman::Receiver::IMAP do
   describe 'connection' do
 
     it 'should connect to a IMAP server' do
-      @receiver.connect.should be_truthy
+      expect(@receiver.connect).to be_truthy
     end
 
     it 'should disconnect from a IMAP server' do
       @receiver.connect
-      @receiver.disconnect.should be_truthy
+      expect(@receiver.disconnect).to be_truthy
     end
 
     it 'should retry on a ByeResponseError from the IMAP server' do
       mock_imap = mock_imap_with_select_error(Net::IMAP::ByeResponseError, 5)
-      Net::IMAP.should_receive(:new).and_return(mock_imap)
+      expect(Net::IMAP).to receive(:new).and_return(mock_imap)
       @receiver.connect
     end
 
     it 'should retry on a NoResponseError from the IMAP server' do
       mock_imap = mock_imap_with_select_error(Net::IMAP::NoResponseError, 5)
-      Net::IMAP.should_receive(:new).and_return(mock_imap)
+      expect(Net::IMAP).to receive(:new).and_return(mock_imap)
       @receiver.connect
     end
 
     it 'should raise on other errors from the IMAP server' do
       mock_imap = mock_imap_with_select_error(Net::IMAP::BadResponseError, 1)
-      Net::IMAP.should_receive(:new).and_return(mock_imap)
+      expect(Net::IMAP).to receive(:new).and_return(mock_imap)
       expect{@receiver.connect}.to raise_error(Net::IMAP::BadResponseError)
     end
 
@@ -50,13 +50,13 @@ describe Mailman::Receiver::IMAP do
     end
 
     it 'should get messages and process them' do
-      @processor.should_receive(:process).twice.with(/test/)
+      expect(@processor).to receive(:process).twice.with(/test/)
       @receiver.get_messages
     end
 
     it 'should delete the messages after processing' do
       @receiver.get_messages
-      @receiver.connection.search(:all).should be_empty
+      expect(@receiver.connection.search(:all)).to be_empty
     end
 
   end
@@ -71,8 +71,7 @@ describe Mailman::Receiver::IMAP do
 
   def mock_imap_with_select_error(error_type, attempts)
     mock_imap = MockIMAP.new
-    mock_imap
-      .should_receive(:select)
+    expect(mock_imap).to receive(:select)
       .with(/INBOX/)
       .exactly(attempts).times
       .and_raise(error_type.new(@error_response))

--- a/spec/mailman/receiver/pop3_spec.rb
+++ b/spec/mailman/receiver/pop3_spec.rb
@@ -15,12 +15,12 @@ describe Mailman::Receiver::POP3 do
 
   describe 'connection' do
     it 'should connect to a POP3 server' do
-      @receiver.connect.should be_truthy
+      expect(@receiver.connect).to be_truthy
     end
 
     it 'should disconnect from a POP3 server' do
       @receiver.connect
-      @receiver.disconnect.should be_truthy
+      expect(@receiver.disconnect).to be_truthy
     end
   end
 
@@ -30,13 +30,13 @@ describe Mailman::Receiver::POP3 do
     end
 
     it 'should get messages and process them' do
-      @processor.should_receive(:process).twice.with(/test/)
+      expect(@processor).to receive(:process).twice.with(/test/)
       @receiver.get_messages
     end
 
     it 'should delete the messages after processing' do
       @receiver.get_messages
-      @receiver.connection.mails.should be_empty
+      expect(@receiver.connection.mails).to be_empty
     end
   end
 

--- a/spec/mailman/route/condition_spec.rb
+++ b/spec/mailman/route/condition_spec.rb
@@ -3,21 +3,21 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '/spec_he
 describe Mailman::Route::Condition do
 
   it 'should have base methods to override' do
-    lambda { Mailman::Route::Condition.new('test').match('test') }.should raise_error(NotImplementedError)
+    expect { Mailman::Route::Condition.new('test').match('test') }.to raise_error(NotImplementedError)
   end
 
   it 'should store the matcher' do
-    Mailman::Route::Condition.new(/test/).matcher.class.should == Mailman::Route::RegexpMatcher
-    Mailman::Route::Condition.new('test').matcher.class.should == Mailman::Route::StringMatcher
+    expect(Mailman::Route::Condition.new(/test/).matcher.class).to eq(Mailman::Route::RegexpMatcher)
+    expect(Mailman::Route::Condition.new('test').matcher.class).to eq(Mailman::Route::StringMatcher)
   end
 
   it 'should define condition methods on Route' do
     block = Proc.new { test }
     route = Mailman::Route.new
-    route.test('foo').should == route
-    route.test('foo', &block).should be_truthy
-    route.conditions.first.class.should == TestCondition
-    route.block.should == block
+    expect(route.test('foo')).to eq(route)
+    expect(route.test('foo', &block)).to be_truthy
+    expect(route.conditions.first.class).to eq(TestCondition)
+    expect(route.block).to eq(block)
   end
 
 end

--- a/spec/mailman/route/conditions_spec.rb
+++ b/spec/mailman/route/conditions_spec.rb
@@ -3,19 +3,19 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '/spec_he
 describe Mailman::Route::ToCondition do
 
   it 'should match an address' do
-    Mailman::Route::ToCondition.new('test').match(basic_message).should == [{}, []]
+    expect(Mailman::Route::ToCondition.new('test').match(basic_message)).to eq([{}, []])
   end
 
   it 'should not match a non-matching address' do
-    Mailman::Route::ToCondition.new('foo').match(basic_message).should be_nil
+    expect(Mailman::Route::ToCondition.new('foo').match(basic_message)).to be_nil
   end
 
   it 'should not match a nil address' do
-    Mailman::Route::ToCondition.new('test').match(Mail.new).should be_nil
+    expect(Mailman::Route::ToCondition.new('test').match(Mail.new)).to be_nil
   end
 
   it 'should define a method on Route that is chainable and stores the condition' do
-    Mailman::Route.new.to('test').conditions[0].class.should == Mailman::Route::ToCondition
+    expect(Mailman::Route.new.to('test').conditions[0].class).to eq(Mailman::Route::ToCondition)
   end
 
 end
@@ -23,15 +23,15 @@ end
 describe Mailman::Route::FromCondition do
 
   it 'should match an address' do
-    Mailman::Route::FromCondition.new('chunky').match(basic_message).should == [{}, []]
+    expect(Mailman::Route::FromCondition.new('chunky').match(basic_message)).to eq([{}, []])
   end
 
   it 'should not match a non-matching address' do
-    Mailman::Route::FromCondition.new('foo').match(basic_message).should be_nil
+    expect(Mailman::Route::FromCondition.new('foo').match(basic_message)).to be_nil
   end
 
   it 'should define a method on Route that is chainable and stores the condition' do
-    Mailman::Route.new.from('test').conditions[0].class.should == Mailman::Route::FromCondition
+    expect(Mailman::Route.new.from('test').conditions[0].class).to eq(Mailman::Route::FromCondition)
   end
 
 end
@@ -39,15 +39,15 @@ end
 describe Mailman::Route::SubjectCondition do
 
   it 'should match the subject' do
-    Mailman::Route::SubjectCondition.new('Hello').match(basic_message).should == [{}, []]
+    expect(Mailman::Route::SubjectCondition.new('Hello').match(basic_message)).to eq([{}, []])
   end
 
   it 'should not match a non-matching subject' do
-    Mailman::Route::SubjectCondition.new('foo').match(basic_message).should be_nil
+    expect(Mailman::Route::SubjectCondition.new('foo').match(basic_message)).to be_nil
   end
 
   it 'should define a method on Route that is chainable and stores the condition' do
-    Mailman::Route.new.subject('test').conditions[0].class.should == Mailman::Route::SubjectCondition
+    expect(Mailman::Route.new.subject('test').conditions[0].class).to eq(Mailman::Route::SubjectCondition)
   end
 
 end
@@ -55,23 +55,23 @@ end
 describe Mailman::Route::BodyCondition do
 
   it 'should match the body' do
-    Mailman::Route::BodyCondition.new('email').match(basic_message).should == [{}, []]
+    expect(Mailman::Route::BodyCondition.new('email').match(basic_message)).to eq([{}, []])
   end
 
   it 'should not match a non-matching body' do
-    Mailman::Route::BodyCondition.new('foo').match(basic_message).should be_nil
+    expect(Mailman::Route::BodyCondition.new('foo').match(basic_message)).to be_nil
   end
 
   it 'should define a method on Route that is chainable and stores the condition' do
-    Mailman::Route.new.body('test').conditions[0].class.should == Mailman::Route::BodyCondition
+    expect(Mailman::Route.new.body('test').conditions[0].class).to eq(Mailman::Route::BodyCondition)
   end
 
   it 'returns nil for a non-matching body of a multipart message' do
-    Mailman::Route::BodyCondition.new('foo').match(multipart_message).should be_nil
+    expect(Mailman::Route::BodyCondition.new('foo').match(multipart_message)).to be_nil
   end
 
   it 'matches on the body of a multipart message' do
-    Mailman::Route::BodyCondition.new('plain').match(multipart_message).should == [{}, []]
+    expect(Mailman::Route::BodyCondition.new('plain').match(multipart_message)).to eq([{}, []])
   end
 
 end
@@ -79,19 +79,19 @@ end
 describe Mailman::Route::CcCondition do
 
   it 'should match an address' do
-    Mailman::Route::CcCondition.new('testing').match(basic_message).should == [{}, []]
+    expect(Mailman::Route::CcCondition.new('testing').match(basic_message)).to eq([{}, []])
   end
 
   it 'should not match a non-matching address' do
-    Mailman::Route::CcCondition.new('foo').match(basic_message).should be_nil
+    expect(Mailman::Route::CcCondition.new('foo').match(basic_message)).to be_nil
   end
 
   it 'should not match a nil address' do
-    Mailman::Route::CcCondition.new('testing').match(Mail.new).should be_nil
+    expect(Mailman::Route::CcCondition.new('testing').match(Mail.new)).to be_nil
   end
 
   it 'should define a method on Route that is chainable and stores the condition' do
-    Mailman::Route.new.cc('testing').conditions[0].class.should == Mailman::Route::CcCondition
+    expect(Mailman::Route.new.cc('testing').conditions[0].class).to eq(Mailman::Route::CcCondition)
   end
 
 end

--- a/spec/mailman/route/matcher_spec.rb
+++ b/spec/mailman/route/matcher_spec.rb
@@ -7,23 +7,23 @@ describe Mailman::Route::Matcher do
   end
 
   it 'should have base methods to override' do
-    lambda { @matcher.match('test') }.should raise_error(NotImplementedError)
-    lambda { Mailman::Route::Matcher.valid_pattern?('test') }.should raise_error(NotImplementedError)
-    @matcher.respond_to?(:compile!).should be_truthy
+    expect { @matcher.match('test') }.to raise_error(NotImplementedError)
+    expect { Mailman::Route::Matcher.valid_pattern?('test') }.to raise_error(NotImplementedError)
+    expect(@matcher.respond_to?(:compile!)).to be_truthy
   end
 
   it 'should store the pattern' do
-    @matcher.pattern.should == 'test'
+    expect(@matcher.pattern).to eq('test')
   end
 
   it 'should call #compile! when initialized' do
-    TestMatcher.new('test').compiled.should be_truthy
+    expect(TestMatcher.new('test').compiled).to be_truthy
   end
 
   describe 'singleton' do
 
     it 'should have an array of registered matchers' do
-      Mailman::Route::Matcher.matchers.should include(TestMatcher)
+      expect(Mailman::Route::Matcher.matchers).to include(TestMatcher)
     end
 
     it 'should be able to find and create a matcher instance' do
@@ -31,9 +31,9 @@ describe Mailman::Route::Matcher do
       original_matchers = matcher_class.instance_variable_get('@matchers')
       matcher_class.instance_variable_set('@matchers', [TestMatcher])
       matcher = matcher_class.create('test')
-      matcher.class.should == TestMatcher
-      matcher.pattern.should == 'test'
-      TestMatcher.validated.should == true
+      expect(matcher.class).to eq(TestMatcher)
+      expect(matcher.pattern).to eq('test')
+      expect(TestMatcher.validated).to eq(true)
       matcher_class.instance_variable_set('@matchers', original_matchers)
     end
 

--- a/spec/mailman/route/regexp_matcher_spec.rb
+++ b/spec/mailman/route/regexp_matcher_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '/spec_he
 describe Mailman::Route::RegexpMatcher do
 
   it 'should be registered with Matcher' do
-    Mailman::Route::Matcher.create(/test/).class.should == Mailman::Route::RegexpMatcher
+    expect(Mailman::Route::Matcher.create(/test/).class).to eq(Mailman::Route::RegexpMatcher)
   end
 
   describe 'basic' do
@@ -13,15 +13,15 @@ describe Mailman::Route::RegexpMatcher do
     end
 
     it 'should store a pattern' do
-      @matcher.pattern.should == /test/
+      expect(@matcher.pattern).to eq(/test/)
     end
 
     it 'should match a string' do
-      @matcher.match('test').should be_truthy
+      expect(@matcher.match('test')).to be_truthy
     end
 
     it 'should not match a non-matching string' do
-      @matcher.match('foo').should be_nil
+      expect(@matcher.match('foo')).to be_nil
     end
 
   end
@@ -30,11 +30,11 @@ describe Mailman::Route::RegexpMatcher do
 
     it 'should return a captures hash and array with matches' do
       correct_captures = ['test', 'example.com']
-      regexp_matcher(/(.*)@(.*)/).match('test@example.com').should == [{:captures => correct_captures}, correct_captures]
+      expect(regexp_matcher(/(.*)@(.*)/).match('test@example.com')).to eq([{:captures => correct_captures}, correct_captures])
     end
 
     it 'should return empty capture arrays if there were no captures' do
-      regexp_matcher(/test/).match('test').should == [{:captures => []}, []]
+      expect(regexp_matcher(/test/).match('test')).to eq([{:captures => []}, []])
     end
 
   end

--- a/spec/mailman/route/string_matcher_spec.rb
+++ b/spec/mailman/route/string_matcher_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '/spec_he
 describe Mailman::Route::StringMatcher do
 
   it 'should be registered with Matcher' do
-    Mailman::Route::Matcher.create('test').class.should == Mailman::Route::StringMatcher
+    expect(Mailman::Route::Matcher.create('test').class).to eq(Mailman::Route::StringMatcher)
   end
 
   describe 'compiler' do
@@ -13,11 +13,11 @@ describe Mailman::Route::StringMatcher do
     end
 
     it 'should compile to a regular expression' do
-      @matcher.pattern.should == /(.*)@example\.com/i
+      expect(@matcher.pattern).to eq(/(.*)@example\.com/i)
     end
 
     it 'should turn tokens into keys' do
-      @matcher.keys.should == [:user]
+      expect(@matcher.keys).to eq([:user])
     end
 
   end
@@ -26,40 +26,40 @@ describe Mailman::Route::StringMatcher do
 
     it 'should return a hash of named params and an array of captures' do
       correct_result = [{ :user_name => 'test', :domain => 'example.com' }, ['test', 'example.com']]
-      string_matcher('%user_name%@%domain%').match('test@example.com').should == correct_result
+      expect(string_matcher('%user_name%@%domain%').match('test@example.com')).to eq(correct_result)
     end
 
     it 'should return empty results if there are no captures' do
-      string_matcher('test@example.com').match('test@example.com').should == [{}, []]
+      expect(string_matcher('test@example.com').match('test@example.com')).to eq([{}, []])
     end
 
     it 'should match a complex string' do
       matcher = string_matcher('%user%@example.com')
       address = "bob1234!$##%&'*+-/=?^_`{}|.~@example.com"
-      matcher.match(address)[1][0].should == "bob1234!$##%&'*+-/=?^_`{}|.~"
+      expect(matcher.match(address)[1][0]).to eq("bob1234!$##%&'*+-/=?^_`{}|.~")
     end
 
     it 'should capture a partial string' do
       matcher = string_matcher('%user%-unsubscribe@example.com')
-      matcher.match('test-unsubscribe@example.com')[1][0].should == 'test'
+      expect(matcher.match('test-unsubscribe@example.com')[1][0]).to eq('test')
     end
 
     it 'should not match a non-matching string' do
-      string_matcher('foobar').match('fuzz').should be_nil
+      expect(string_matcher('foobar').match('fuzz')).to be_nil
     end
 
     it 'should match named params split by a period' do
       matches = string_matcher('test@%domain%.%tld%').match('test@example.com')[1]
-      matches[0].should == 'example'
-      matches[1].should == 'com'
+      expect(matches[0]).to eq('example')
+      expect(matches[1]).to eq('com')
     end
 
     it 'should match a pattern with special characters in it' do
       matcher = string_matcher("(%id%)+ ^|$ \n [%foo%]*\?{%bar%}")
       matches = matcher.match("(55)+ ^|$ \n [test]*\?{2}")[1]
-      matches[0].should == '55'
-      matches[1].should == 'test'
-      matches[2].should == '2'
+      expect(matches[0]).to eq('55')
+      expect(matches[1]).to eq('test')
+      expect(matches[2]).to eq('2')
     end
 
   end

--- a/spec/mailman/route_spec.rb
+++ b/spec/mailman/route_spec.rb
@@ -10,22 +10,22 @@ describe Mailman::Route do
     block = Proc.new { test }
     correct_result = { :block => block, :klass => nil, :params => {:testing => 'test'}, :args => ['testing'] }
     @route.testing('test', &block)
-    @route.match!('test').should == correct_result
+    expect(@route.match!('test')).to eq(correct_result)
   end
 
   it 'should match multiple conditions' do
     block = Proc.new { test }
     correct_result = { :block => block, :klass => nil, :params => {:testing => 'test', :tester => 'test2'}, :args => ['testing', 'test2'] }
     @route.testing('test').tester('test', &block)
-    @route.match!('test').should == correct_result
+    expect(@route.match!('test')).to eq(correct_result)
   end
 
   it 'should not match a non-matching condition' do
-    @route.testing('foo').match!('test').should be_nil
+    expect(@route.testing('foo').match!('test')).to be_nil
   end
 
   it 'should not match if one condition is non-matching' do
-    @route.testing('test').tester('foo').match!('test').should be_nil
+    expect(@route.testing('test').tester('foo').match!('test')).to be_nil
   end
 
 end

--- a/spec/mailman/router_spec.rb
+++ b/spec/mailman/router_spec.rb
@@ -7,8 +7,8 @@ describe Mailman::Router do
   end
 
   it 'should add a route' do
-    @router.add_route('test').should == 'test'
-    @router.routes.should == ['test']
+    expect(@router.add_route('test')).to eq('test')
+    expect(@router.routes).to eq(['test'])
   end
 
   describe 'routing' do
@@ -22,16 +22,20 @@ describe Mailman::Router do
     describe 'blocks' do
 
       it 'should work without args' do
-        @route1.block = lambda { params[:test].should == 'test'
-                                 message.should == 'test1' }
+        @route1.block = lambda {
+          raise "Params unavailable" unless params[:test] == 'test'
+          raise "Message unavailable" unless message == 'test1'
+        }
         @router.route('test1')
       end
 
       it 'should work with args' do
-        @route1.block = lambda { |arg1,arg2| arg1.should == 'test'
-                                             arg2.should == 'testing'
-                                             params[:test].should == 'test'
-                                             message.should == 'test1' }
+        @route1.block = lambda { |arg1, arg2|
+          raise "Argument 1 unavailable" unless arg1 == 'test'
+          raise "Argument 2 unavailable" unless arg2 == 'testing'
+          raise "Params unavailable" unless params[:test] == 'test'
+          raise "Message unavailable" unless message == 'test1'
+        }
         @router.route('test1')
       end
 
@@ -41,19 +45,21 @@ describe Mailman::Router do
 
       it 'should route to the default method' do
         @route1.klass = TestMailer
-        @router.route('test1').should be_truthy
+        expect(@router.route('test1')).to be_truthy
       end
 
       it 'should route to the specified method' do
         @route1.klass = 'testMailer#get'
-        @router.route('test1').should be_truthy
+        expect(@router.route('test1')).to be_truthy
       end
 
     end
 
     it 'should set the params helper to a indifferent hash' do
-      @route1.block = lambda { params[:test].should == 'test'
-                               params['test'].should == 'test' }
+      @route1.block = proc {
+        raise "Symbol access unavailable" unless params[:test] == 'test'
+        raise "String access unavailable" unless params['test'] == 'test'
+      }
       @router.route('test1')
     end
 
@@ -67,14 +73,14 @@ describe Mailman::Router do
       it 'should loop through routes and find the first route that matches' do
         @route2.block = lambda { 2 }
         @route2.correct_message = 'test2'
-        @router.route('test2').should == 2
+        expect(@router.route('test2')).to eq(2)
       end
 
       it 'should run the first route that matches with two matching routes' do
         @route2.correct_message = 'test1'
         @route1.block = lambda { 1 }
         @route2.block = lambda { 2 }
-        @router.route('test1').should == 1
+        expect(@router.route('test1')).to eq(1)
       end
 
     end
@@ -88,14 +94,14 @@ describe Mailman::Router do
       it 'should run the bounce block if it exists' do
         message = double('bounced message', :bounced? => true)
         @route1.correct_message = message
-        @router.route(message).should == 'bounce'
+        expect(@router.route(message)).to eq('bounce')
       end
 
       it 'should not run the bounce block if the message did not bounce' do
         message = double('bounced message', :bounced? => false)
         @route1.correct_message = message
         @route1.block = lambda { 'nobounce' }
-        @router.route(message).should == 'nobounce'
+        expect(@router.route(message)).to eq('nobounce')
       end
 
     end
@@ -108,13 +114,13 @@ describe Mailman::Router do
 
       it 'should run the default block if it exists and no routes match' do
         @route1.correct_message = 'foobar'
-        @router.route('blah').should == 'default'
+        expect(@router.route('blah')).to eq('default')
       end
 
       it 'should not run the default block if a route matched' do
         @route1.correct_message = 'test'
         @route1.block = lambda { 'nodefault' }
-        @router.route('test').should == 'nodefault'
+        expect(@router.route('test')).to eq('nodefault')
       end
 
     end


### PR DESCRIPTION
I've moved to RSpec 3 (major change is the syntax: `expect` rather than `.should`) which removes the warnings when running tests.